### PR TITLE
En us translation fix and fix missing Category in modern UI

### DIFF
--- a/common/src/main/resources/assets/sdmshop/lang/en_us.json
+++ b/common/src/main/resources/assets/sdmshop/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+  "sdm.shop.modern.ui.tab_categories" : "CATEGORIES",
   "sdm_shop.addtovar.tab" : "Add to tab",
   "sdm_shop.addtovar.additem" : "Add Item",
   "sdm_shop.addtovar.command" : "Command",


### PR DESCRIPTION
Updated some translations to be more accurate.
Also there is a issue where the "CATEGORY" is missing in the modern ui, from other branches it looks like it uses "sdm.shop.modern.ui.tab_categories" : "CATEGORIES",